### PR TITLE
Suggestions for techladyhackathon homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,6 @@ name: Tech Lady Hackathon and Training Day
 description: 'A day for women from experienced coders to total newbies to gather for civic hacking and training in a supportive environment.'
 
 baseurl: /techladyhackathon
+
+gems:
+  - jekyll-redirect-from

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+name: Tech Lady Hackathon and Training Day
+description: 'A day for women from experienced coders to total newbies to gather for civic hacking and training in a supportive environment.'

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 name: Tech Lady Hackathon and Training Day
 description: 'A day for women from experienced coders to total newbies to gather for civic hacking and training in a supportive environment.'
+
+baseurl: /techladyhackathon

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-_<!doctype html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>Tech Lady Hackathon + Training Day by leahbannon</title>
 
-    <link rel="stylesheet" href="stylesheets/styles.css">
-    <link rel="stylesheet" href="stylesheets/pygment_trac.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/styles.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/stylesheets/pygment_trac.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/pages/codeofconduct.html
+++ b/pages/codeofconduct.html
@@ -2,6 +2,7 @@
 layout: main
 published: true
 permalink: /codeofconduct/
+redirect_from: /codeofconduct.html
 ---
 
 <p>We want everyone to have a good time at the TechLady Hackathon. To that end, if you have any questions, comments, or concerns, please do not hesitate to reach out to any of the TechLady teammates (or post questions on the FAQs). We're also adopting the following Guidelines for Awesomeness for all participants. </p>

--- a/pages/codeofconduct.html
+++ b/pages/codeofconduct.html
@@ -1,6 +1,7 @@
 ---
 layout: main
 published: true
+permalink: /codeofconduct/
 ---
 
 <p>We want everyone to have a good time at the TechLady Hackathon. To that end, if you have any questions, comments, or concerns, please do not hesitate to reach out to any of the TechLady teammates (or post questions on the FAQs). We're also adopting the following Guidelines for Awesomeness for all participants. </p>

--- a/pages/donors.html
+++ b/pages/donors.html
@@ -1,6 +1,7 @@
 ---
 layout: main
 published: true
+permalink: /donors/
 ---
 
 <h3>Interested in Supporting Tech Lady Hackathons?</h3>

--- a/pages/donors.html
+++ b/pages/donors.html
@@ -2,6 +2,7 @@
 layout: main
 published: true
 permalink: /donors/
+redirect_from: /donors.html
 ---
 
 <h3>Interested in Supporting Tech Lady Hackathons?</h3>

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -1,6 +1,7 @@
 ---
 layout: main
 published: true
+permalink: /feedback/
 ---
 
 <iframe src="https://docs.google.com/forms/d/1QOEI8_uXrwifmgcLeVqhBtP-lbmyIGgNj80UnQetSTE/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -2,6 +2,7 @@
 layout: main
 published: true
 permalink: /feedback/
+redirect_from: /feedback.html
 ---
 
 <iframe src="https://docs.google.com/forms/d/1QOEI8_uXrwifmgcLeVqhBtP-lbmyIGgNj80UnQetSTE/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,10 +1,11 @@
 ---
 layout: main
 published: true
+permalink: /
 ---
 
 <h3>The next Tech Lady Hackathon + Training Day is in July.</h3> 
-<p><a href="/newsletter">Subscribe to the newsletter</a> to be the first to hear details (and learn about other DC tech lady events and training every month).</p>
+<p><a href="{{ site.baseurl }}/newsletter/">Subscribe to the newsletter</a> to be the first to hear details (and learn about other DC tech lady events and training every month).</p>
 
 <p>Coders, tech strategists, trainers, newbies, and ideas are welcome! Not sure what to expect/bring/do? <a href="https://github.com/leahbannon/old-leah-website/blob/master/_posts/2014-07-23-what-to-expect-at-a-hackathon.md">What to expect at a civic hackathon</a>.</p>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -5,17 +5,19 @@ permalink: /
 ---
 
 <h3>The next Tech Lady Hackathon + Training Day is in July.</h3> 
-<p><a href="{{ site.baseurl }}/newsletter/">Subscribe to the newsletter</a> to be the first to hear details (and learn about other DC tech lady events and training every month).</p>
+<p><a href="{{ site.baseurl }}/newsletter/">Subscribe to the newsletter</a> to be the first to hear details (and learn about other tech lady events and training every month).</p>
 
 <p>Coders, tech strategists, trainers, newbies, and ideas are welcome! Not sure what to expect/bring/do? <a href="https://github.com/leahbannon/old-leah-website/blob/master/_posts/2014-07-23-what-to-expect-at-a-hackathon.md">What to expect at a civic hackathon</a>.</p>
 
-<p>Over 150 women attended the 2nd Tech Lady Hackathon in July. Check out the summary: <a href="http://codefordc.org/blog/2014/07/28/techlady-hackathon-recap.html">The Second Tech Lady Hackathon was Tremendous</a>.</p>
+<p>Over 150 women attended the 2nd Tech Lady Hackathon in July 2014. Check out the summary: <a href="http://codefordc.org/blog/2014/07/28/techlady-hackathon-recap.html">The Second Tech Lady Hackathon was Tremendous</a>.</p>
+
+<p>This year, we're expanding! We've got a sister Tech Lady Hackathon + Training Day in Tucson, Arizona and we're hoping to add more locations soon. Stay tuned to see if Tech Lady is coming to a community near you!</p>
 
 <h3>About the Hackathon and Training</h3>
 
-<p><strong>Training:</strong> We offer basic 101 intro training and mentoring workshops throughout the day - <strong>no prior knowledge of code is necessary</strong>. And we mean none. Some examples of the 101 intro classes we offer are: Ruby, APIs, Python, GitHub, html/CSS, and SQL. Mentoring sessions we offered previously were: Empowerment/imposter syndrome, open gov/open data, and lady mentoring session.</p>
+<p><strong>Training:</strong> We offer basic 101 intro training and mentoring workshops throughout the day — <strong>no prior knowledge of code is necessary</strong>. And we mean none. Some examples of the 101 intro classes we offer are: Ruby, APIs, Python, GitHub, HTML/CSS, and SQL. Mentoring sessions we offered previously were: empowerment/imposter syndrome, open gov/open data, and lady mentoring sessions.</p>
 
-<p><strong>Hackathon:</strong> This is a civic hackathon, and we usually work on projects from <a href="http://codefordc.org">Code for DC</a>, but you're welcome to bring anything and pitch it.</p>
+<p><strong>Hackathon:</strong> This is a civic hackathon, and we usually work on projects from <a href="http://www.codeforamerica.org/brigade/">Code for America Brigades</a>, but you're welcome to bring anything and pitch it.</p>
 
 <h3>Questions? Ideas? Advice?</h3>
 <p>Leah Bannon is the lead organizer of this event. Please feel free to reach out via <a href="http://twitter.com/leahbannon">Twitter</a> with any questions or ideas, or you can check out her personal site at <a href="http://leah.io">Leah.io</a>.</p>

--- a/pages/january2013.html
+++ b/pages/january2013.html
@@ -2,6 +2,7 @@
 layout: main
 published: true
 permalink: /january2013/
+redirect_from: /january2013.html
 ---
 
       <ul>

--- a/pages/january2013.html
+++ b/pages/january2013.html
@@ -1,6 +1,7 @@
 ---
 layout: main
 published: true
+permalink: /january2013/
 ---
 
       <ul>

--- a/pages/lgbteeo.html
+++ b/pages/lgbteeo.html
@@ -1,6 +1,7 @@
 ---
 layout: main
 published: true
+permalink: /lgbteeo/
 ---
 
 <h3>LGBT Equal Employment: What's your policy?</h3>

--- a/pages/lgbteeo.html
+++ b/pages/lgbteeo.html
@@ -2,6 +2,7 @@
 layout: main
 published: true
 permalink: /lgbteeo/
+redirect_from: /lgbteeo.html
 ---
 
 <h3>LGBT Equal Employment: What's your policy?</h3>

--- a/pages/newsletter.html
+++ b/pages/newsletter.html
@@ -2,6 +2,7 @@
 layout: main
 published: true
 permalink: /newsletter/
+redirect_from: /newsletter.html
 ---
 
 <h3>Newsletter</h3>

--- a/pages/newsletter.html
+++ b/pages/newsletter.html
@@ -1,6 +1,7 @@
 ---
 layout: main
 published: true
+permalink: /newsletter/
 ---
 
 <h3>Newsletter</h3>


### PR DESCRIPTION
This PR is to add information about the techlady hackathons and training days in cities other than DC. This requires new language. The PR also includes some code shining (while I was in the there, why not? :) ).

Specifically, this PR:

- Removes stray underscore that was showing up on the top left of the homepage.
- Adds config file to make Jekyll stop complaining.
- Gets subpages working locally to make it easier to preview work before live.
- Adds pretty permalinks.
- Organizes pages into pages folder. _NB: Need to confirm with @leahbannon that this change didn't fubar anything else (links from elsewhere)_
- Suggests new language for homepage to talk about other locations besides DC.
